### PR TITLE
Cursor-based Logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,17 +5,14 @@ set(CMAKE_C_STANDARD 11)
 
 # Main application target
 add_executable(simple_text_editor src/main.cpp
-        src/parser.cpp
-        src/text_storage.cpp
-        src/editor.cpp
-        src/file_handler.cpp
-        include/file_handler.h
-        src/application.cpp
-        include/application.h
-        src/buffer.cpp
-        include/buffer.h
-        src/commands_log.cpp
-        include/commands_log.h
+        src/parser.cpp include/parser.h
+        src/text_storage.cpp include/text_storage.h
+        src/editor.cpp include/editor.h
+        src/file_handler.cpp include/file_handler.h
+        src/application.cpp include/application.h
+        src/buffer.cpp include/buffer.h
+        src/commands_log.cpp include/commands_log.h
+        src/cursor.cpp include/cursor.h
 )
 
 # Add Google Test to the project
@@ -23,12 +20,19 @@ add_subdirectory(cmake-build-debug/googletest)
 
 # Test target
 add_executable(simple_text_editor_tests test/main_test.cpp include/main_test.h
-        test/text_storage_test.cpp src/text_storage.cpp
-        test/parser_test.cpp src/parser.cpp
-        test/editor_test.cpp src/editor.cpp
-        test/file_handler_test.cpp src/file_handler.cpp
-        test/buffer_test.cpp src/buffer.cpp
-        test/commands_log_test.cpp src/commands_log.cpp
+        test/text_storage_test.cpp
+        src/text_storage.cpp
+        test/parser_test.cpp
+        src/parser.cpp
+        test/editor_test.cpp
+        src/editor.cpp
+        test/file_handler_test.cpp
+        src/file_handler.cpp
+        test/buffer_test.cpp
+        src/buffer.cpp
+        test/commands_log_test.cpp
+        src/commands_log.cpp
+        test/cursor_test.cpp src/cursor.cpp
         src/application.cpp
 )
 

--- a/cmake-build-debug/build.ninja
+++ b/cmake-build-debug/build.ninja
@@ -97,6 +97,12 @@ build CMakeFiles/simple_text_editor.dir/src/commands_log.cpp.o: CXX_COMPILER__si
   OBJECT_DIR = CMakeFiles/simple_text_editor.dir
   OBJECT_FILE_DIR = CMakeFiles/simple_text_editor.dir/src
 
+build CMakeFiles/simple_text_editor.dir/src/cursor.cpp.o: CXX_COMPILER__simple_text_editor_unscanned_Debug /Users/owner/Storage/KSE/IT$ Disciplines/PP/simple-text-editor/src/cursor.cpp || cmake_object_order_depends_target_simple_text_editor
+  DEP_FILE = CMakeFiles/simple_text_editor.dir/src/cursor.cpp.o.d
+  FLAGS = -g -std=gnu++11 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -fcolor-diagnostics
+  OBJECT_DIR = CMakeFiles/simple_text_editor.dir
+  OBJECT_FILE_DIR = CMakeFiles/simple_text_editor.dir/src
+
 
 # =============================================================================
 # Link build statements for EXECUTABLE target simple_text_editor
@@ -105,7 +111,7 @@ build CMakeFiles/simple_text_editor.dir/src/commands_log.cpp.o: CXX_COMPILER__si
 #############################################
 # Link the executable simple_text_editor
 
-build simple_text_editor: CXX_EXECUTABLE_LINKER__simple_text_editor_Debug CMakeFiles/simple_text_editor.dir/src/main.cpp.o CMakeFiles/simple_text_editor.dir/src/parser.cpp.o CMakeFiles/simple_text_editor.dir/src/text_storage.cpp.o CMakeFiles/simple_text_editor.dir/src/editor.cpp.o CMakeFiles/simple_text_editor.dir/src/file_handler.cpp.o CMakeFiles/simple_text_editor.dir/src/application.cpp.o CMakeFiles/simple_text_editor.dir/src/buffer.cpp.o CMakeFiles/simple_text_editor.dir/src/commands_log.cpp.o
+build simple_text_editor: CXX_EXECUTABLE_LINKER__simple_text_editor_Debug CMakeFiles/simple_text_editor.dir/src/main.cpp.o CMakeFiles/simple_text_editor.dir/src/parser.cpp.o CMakeFiles/simple_text_editor.dir/src/text_storage.cpp.o CMakeFiles/simple_text_editor.dir/src/editor.cpp.o CMakeFiles/simple_text_editor.dir/src/file_handler.cpp.o CMakeFiles/simple_text_editor.dir/src/application.cpp.o CMakeFiles/simple_text_editor.dir/src/buffer.cpp.o CMakeFiles/simple_text_editor.dir/src/commands_log.cpp.o CMakeFiles/simple_text_editor.dir/src/cursor.cpp.o
   FLAGS = -g -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk
   OBJECT_DIR = CMakeFiles/simple_text_editor.dir
   POST_BUILD = :
@@ -213,6 +219,20 @@ build CMakeFiles/simple_text_editor_tests.dir/src/commands_log.cpp.o: CXX_COMPIL
   OBJECT_DIR = CMakeFiles/simple_text_editor_tests.dir
   OBJECT_FILE_DIR = CMakeFiles/simple_text_editor_tests.dir/src
 
+build CMakeFiles/simple_text_editor_tests.dir/test/cursor_test.cpp.o: CXX_COMPILER__simple_text_editor_tests_unscanned_Debug /Users/owner/Storage/KSE/IT$ Disciplines/PP/simple-text-editor/test/cursor_test.cpp || cmake_object_order_depends_target_simple_text_editor_tests
+  DEP_FILE = CMakeFiles/simple_text_editor_tests.dir/test/cursor_test.cpp.o.d
+  FLAGS = -g -std=gnu++14 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -fcolor-diagnostics
+  INCLUDES = -isystem "/Users/owner/Storage/KSE/IT Disciplines/PP/simple-text-editor/cmake-build-debug/googletest/googletest/include" -isystem "/Users/owner/Storage/KSE/IT Disciplines/PP/simple-text-editor/cmake-build-debug/googletest/googletest"
+  OBJECT_DIR = CMakeFiles/simple_text_editor_tests.dir
+  OBJECT_FILE_DIR = CMakeFiles/simple_text_editor_tests.dir/test
+
+build CMakeFiles/simple_text_editor_tests.dir/src/cursor.cpp.o: CXX_COMPILER__simple_text_editor_tests_unscanned_Debug /Users/owner/Storage/KSE/IT$ Disciplines/PP/simple-text-editor/src/cursor.cpp || cmake_object_order_depends_target_simple_text_editor_tests
+  DEP_FILE = CMakeFiles/simple_text_editor_tests.dir/src/cursor.cpp.o.d
+  FLAGS = -g -std=gnu++14 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -fcolor-diagnostics
+  INCLUDES = -isystem "/Users/owner/Storage/KSE/IT Disciplines/PP/simple-text-editor/cmake-build-debug/googletest/googletest/include" -isystem "/Users/owner/Storage/KSE/IT Disciplines/PP/simple-text-editor/cmake-build-debug/googletest/googletest"
+  OBJECT_DIR = CMakeFiles/simple_text_editor_tests.dir
+  OBJECT_FILE_DIR = CMakeFiles/simple_text_editor_tests.dir/src
+
 build CMakeFiles/simple_text_editor_tests.dir/src/application.cpp.o: CXX_COMPILER__simple_text_editor_tests_unscanned_Debug /Users/owner/Storage/KSE/IT$ Disciplines/PP/simple-text-editor/src/application.cpp || cmake_object_order_depends_target_simple_text_editor_tests
   DEP_FILE = CMakeFiles/simple_text_editor_tests.dir/src/application.cpp.o.d
   FLAGS = -g -std=gnu++14 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -fcolor-diagnostics
@@ -228,7 +248,7 @@ build CMakeFiles/simple_text_editor_tests.dir/src/application.cpp.o: CXX_COMPILE
 #############################################
 # Link the executable simple_text_editor_tests
 
-build simple_text_editor_tests: CXX_EXECUTABLE_LINKER__simple_text_editor_tests_Debug CMakeFiles/simple_text_editor_tests.dir/test/main_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/text_storage_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/text_storage.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/parser_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/parser.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/editor_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/editor.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/file_handler_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/file_handler.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/buffer_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/buffer.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/commands_log_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/commands_log.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/application.cpp.o | lib/libgtest_main.a lib/libgtest.a || lib/libgtest.a lib/libgtest_main.a
+build simple_text_editor_tests: CXX_EXECUTABLE_LINKER__simple_text_editor_tests_Debug CMakeFiles/simple_text_editor_tests.dir/test/main_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/text_storage_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/text_storage.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/parser_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/parser.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/editor_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/editor.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/file_handler_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/file_handler.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/buffer_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/buffer.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/commands_log_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/commands_log.cpp.o CMakeFiles/simple_text_editor_tests.dir/test/cursor_test.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/cursor.cpp.o CMakeFiles/simple_text_editor_tests.dir/src/application.cpp.o | lib/libgtest_main.a lib/libgtest.a || lib/libgtest.a lib/libgtest_main.a
   FLAGS = -g -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk
   LINK_LIBRARIES = lib/libgtest_main.a  lib/libgtest.a
   OBJECT_DIR = CMakeFiles/simple_text_editor_tests.dir

--- a/include/application.h
+++ b/include/application.h
@@ -4,10 +4,11 @@
 #include "buffer.h"
 #include "commands_log.h"
 #include "editor.h"
+#include "cursor.h"
 
 class Application {
 public:
-    Application() : content(), buffer(), cmdLog() {}
+    Application() : content(), buffer(), cmdLog(), cursor() {}
     static void printCommandsInfo();
     static void clearConsole();
     void executeCommand();
@@ -17,4 +18,5 @@ public:
     int command;
     Buffer buffer;
     CommandsLog cmdLog;
+    Cursor cursor;
 };

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -2,6 +2,7 @@
 #include <iostream>
 #include "text_storage.h"
 #include "commands_log.h"
+#include "cursor.h"
 
 class Buffer {
 private:
@@ -10,7 +11,7 @@ public:
     Buffer();
 
     char* getClip();
-    void cut(LinkedList* content, CommandsLog* cmdLog, int lineIndex, int charIndex, size_t length);
-    void copy(LinkedList* content, int lineIndex, int charIndex, size_t length);
-    void paste(LinkedList* content, CommandsLog* cmdLog, int lineIndex, int charIndex);
+    void cut(CommandsLog* cmdLog, Cursor c, size_t length);
+    void copy(Cursor c, size_t length);
+    void paste(CommandsLog* cmdLog, Cursor c);
 };

--- a/include/commands_log.h
+++ b/include/commands_log.h
@@ -1,10 +1,11 @@
 #pragma once
 #include <cstddef>
 #include "text_storage.h"
+#include "cursor.h"
 
 typedef struct LineLog {
-    Line before = nullptr;
-    Line after = nullptr;
+    char* before = nullptr;
+    char* after = nullptr;
     int lineIndex;
 } LineLog;
 
@@ -18,8 +19,8 @@ public:
     CommandsLog();
     LineLog getLineLog(int index);
 
-    void logBefore(const Line& line, int lineIndex);
-    void logAfter(const Line& line);
-    void undo(LinkedList* content);
-    void redo(LinkedList* content);
+    void logBefore(const char* text, int lineIndex);
+    void logAfter(const char* text);
+    void undo(LinkedList* content, Cursor& cursor);
+    void redo(LinkedList* content, Cursor& cursor);
 };

--- a/include/cursor.h
+++ b/include/cursor.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "text_storage.h"
+
+class Cursor {
+private:
+    Line* line;
+    int lineIndex;
+    int charIndex;
+public:
+    Cursor();
+    Line* getCursorLine() const; // const prevents the method from modifying the object
+    int getCursorLineIndex() const;
+    int getCursorCharIndex() const;
+    void setCursor(LinkedList *content, int lineIdx, int charIdx);
+    void updateCursor(Line *tail, int lineIdx, int charIdx);
+};

--- a/include/editor.h
+++ b/include/editor.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "text_storage.h"
 #include "commands_log.h"
+#include "cursor.h"
 
 class Editor {
 public:
@@ -8,8 +9,7 @@ public:
     static void printText(LinkedList* content);
     static void appendText(LinkedList* content, CommandsLog* cmdLog, const char* text);
     static void search(LinkedList* content, const char* pattern);
-    static void insertBy(LinkedList* content, CommandsLog* cmdLog, int lineIndex, int charIndex, const char* newText);
-    static void replaceBy(LinkedList* content, CommandsLog* cmdLog, int lineIndex, int charIndex, const char* newText);
-    static void deleteBy(LinkedList* content, CommandsLog* cmdLog, int lineIndex, int charIndex, size_t length);
-    static Line* setPosition(LinkedList* content, int lineIndex, int charIndex);
+    static void insertText(CommandsLog* cmdLog, Cursor c, const char* newText);
+    static void replaceText(CommandsLog* cmdLog, Cursor c, const char* newText);
+    static void deleteText(CommandsLog* cmdLog, Cursor c, size_t length);
 };

--- a/include/file_handler.h
+++ b/include/file_handler.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "text_storage.h"
 #include "commands_log.h"
+#include "cursor.h"
 
 class FileHandler {
 public:

--- a/include/text_storage.h
+++ b/include/text_storage.h
@@ -5,8 +5,7 @@ public:
     char* text;
     Line* next;
 
-    Line() {}; // Default constructor
-    Line(const Line& other); // Copy constructor
+    Line() = default; // Default constructor
     Line(const char* userText);
 };
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -4,21 +4,22 @@
 
 void Application::printCommandsInfo() {
     std::cout << "0 - Help\n"
-              << "1 - Append to the end\n"
-              << "2 - New line\n"
-              << "3 - Save into the file\n"
-              << "4 - Load from the file\n"
-              << "5 - Print current text\n"
-              << "6 - Insert by line and index\n"
-              << "7 - Replace by line and index\n"
-              << "8 - Delete by line and index\n"
-              << "9 - Search\n"
-              << "10 - Cut\n"
-              << "11 - Copy\n"
-              << "12 - Paste\n"
-              << "13 - Undo\n"
-              << "14 - Redo\n"
-              << "15 - Exit\n";
+              << "1 - Set cursor\n"
+              << "2 - Print current text\n"
+              << "3 - New line\n"
+              << "4 - Append to the end\n"
+              << "5 - Insert by line and index\n"
+              << "6 - Replace by line and index\n"
+              << "7 - Delete by line and index\n"
+              << "8 - Cut\n"
+              << "9 - Copy\n"
+              << "10 - Paste\n"
+              << "11 - Search\n"
+              << "12 - Save into the file\n"
+              << "13 - Load from the file\n"
+              << "14 - Undo\n"
+              << "15 - Redo\n"
+              << "16 - Exit\n";
 }
 
 void  Application::clearConsole() {
@@ -32,57 +33,54 @@ void  Application::executeCommand() {
             printCommandsInfo();
             return;
         case 1:
-            Editor::appendText(&content, &cmdLog, Parser::readText());
+            cursor.setCursor(&content, Parser::readInteger("Enter a line index: "), Parser::readInteger("Enter a char index: "));
             return;
         case 2:
-            Editor::newLine(&content, &cmdLog, Parser::readText());
-            return;
-        case 3:
-            FileHandler::saveToFile(&content,Parser::readText());
-            return;
-        case 4:
-            FileHandler::loadFromFile(&content, &cmdLog, Parser::readText());
-            return;
-        case 5:
             Editor::printText(&content);
             return;
+        case 3:
+            Editor::newLine(&content, &cmdLog, Parser::readText());
+            cursor.updateCursor(content.tail, content.length - 1, 0);
+            return;
+        case 4:
+            Editor::appendText(&content, &cmdLog, Parser::readText());
+            if (content.length == 1)
+                cursor.updateCursor(content.tail, content.length - 1, 0);
+            return;
+        case 5:
+            Editor::insertText(&cmdLog, cursor, Parser::readText());
+            return;
         case 6:
-            Editor::insertBy(&content, &cmdLog,Parser::readInteger("Enter a line index: "),
-                             Parser::readInteger("Enter a char index: "), Parser::readText());
+            Editor::replaceText(&cmdLog, cursor, Parser::readText());
             return;
         case 7:
-            Editor::replaceBy(&content, &cmdLog, Parser::readInteger("Enter a line index: "),
-                              Parser::readInteger("Enter a char index: "), Parser::readText());
+            Editor::deleteText(&cmdLog, cursor, Parser::readInteger("Enter a length to delete: "));
             return;
         case 8:
-            Editor::deleteBy(&content, &cmdLog, Parser::readInteger("Enter a line index: "),
-                             Parser::readInteger("Enter a char index: "),
-                             Parser::readInteger("Enter a length: "));
+            buffer.cut(&cmdLog, cursor, Parser::readInteger("Enter a length to cut: "));
             return;
         case 9:
-            Editor::search(&content, Parser::readText());
+            buffer.copy(cursor, Parser::readInteger("Enter a length to copy: "));
             return;
         case 10:
-            buffer.cut(&content, &cmdLog, Parser::readInteger("Enter a line index: "),
-                        Parser::readInteger("Enter a char index: "),
-                        Parser::readInteger("Enter a length: "));
+            buffer.paste(&cmdLog, cursor);
             return;
         case 11:
-            buffer.copy(&content, Parser::readInteger("Enter a line index: "),
-                         Parser::readInteger("Enter a char index: "),
-                         Parser::readInteger("Enter a length: "));
+            Editor::search(&content, Parser::readText());
             return;
         case 12:
-            buffer.paste(&content, &cmdLog, Parser::readInteger("Enter a line index: "),
-                          Parser::readInteger("Enter a char index: "));
+            FileHandler::saveToFile(&content,Parser::readText());
             return;
         case 13:
-            cmdLog.undo(&content);
+            FileHandler::loadFromFile(&content, &cmdLog, Parser::readText());
             return;
         case 14:
-            cmdLog.redo(&content);
+            cmdLog.undo(&content, cursor);
             return;
-        case 15: // Exit
+        case 15:
+            cmdLog.redo(&content, cursor);
+            return;
+        case 16: // Exit
             std::cout << "Bye!";
             return;
         default:
@@ -97,5 +95,5 @@ void Application::run() {
         command = Parser::readInteger("Choose a command (0-8): ");
         clearConsole();
         executeCommand();
-    } while (command != 15);  // 8 - exit command
+    } while (command != 16);  // 8 - exit command
 }

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -10,22 +10,21 @@ char* Buffer::getClip() {
 }
 
 
-void Buffer::cut(LinkedList* content, CommandsLog* cmdLog, int lineIndex, int charIndex, size_t length) {
-    copy(content, lineIndex, charIndex, length);
-    Editor::deleteBy(content, cmdLog, lineIndex, charIndex, length);
+void Buffer::cut(CommandsLog* cmdLog, Cursor c, size_t length) {
+    copy(c, length);
+    Editor::deleteText(cmdLog, c, length);
 }
 
-void Buffer::copy(LinkedList* content, int lineIndex, int charIndex, size_t length) {
-    Line *line = Editor::setPosition(content, lineIndex, charIndex);
-    if (line) {
-        delete[] clip; // deallocate to avoid a memory leak
-        clip = new char[length + 1];
-        std::copy(line->text + charIndex, line->text + charIndex + length, clip);
-        clip[length] = '\0'; // null-terminate the string
-    }
+void Buffer::copy(Cursor c, size_t length) {
+    Line* line = c.getCursorLine();
+    int charIndex = c.getCursorCharIndex();
+    delete[] clip; // deallocate to avoid a memory leak
+    clip = new char[length + 1];
+    std::copy(line->text + charIndex, line->text + charIndex + length, clip);
+    clip[length] = '\0'; // null-terminate the string
 }
 
-void Buffer::paste(LinkedList* content, CommandsLog* cmdLog, int lineIndex, int charIndex) {
+void Buffer::paste(CommandsLog* cmdLog, Cursor c) {
     if (clip)
-        Editor::insertBy(content, cmdLog,  lineIndex, charIndex, clip);
+        Editor::insertText(cmdLog, c, clip);
 }

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include "../include/cursor.h"
+
+Cursor::Cursor() {
+    line = nullptr;
+    lineIndex = 0;
+    charIndex = 0;
+}
+
+Line* Cursor::getCursorLine() const {
+    return line;
+}
+
+int Cursor::getCursorLineIndex() const {
+    return lineIndex;
+}
+
+int Cursor::getCursorCharIndex() const {
+    return charIndex;
+}
+
+void Cursor::setCursor(LinkedList *content, int lineIdx, int charIdx) {
+    if (lineIdx < content->length) {
+        Line* currentLine = content->head;
+        for (int i = 0; i < lineIdx; i++)
+            currentLine = currentLine->next;
+
+        if (charIdx <= strlen(currentLine->text))
+            updateCursor(currentLine, lineIdx, charIdx);
+        else {
+            std::cerr << "Char index is out of bounds.";
+            std::cin.get();
+        }
+    } else {
+        std::cerr << "Line index is out of bounds.";
+        std::cin.get();
+    }
+}
+
+void Cursor::updateCursor(Line *tail, int lineIdx, int charIdx) {
+    this->line = tail;
+    this->lineIndex = lineIdx;
+    this->charIndex = charIdx;
+}

--- a/src/text_storage.cpp
+++ b/src/text_storage.cpp
@@ -10,15 +10,6 @@ Line::Line(const char* userText) {
     next = nullptr;  // Initialize memory
 }
 
-Line::Line(const Line& other) {
-    text = nullptr;
-    if (other.text) {
-        text = new char[strlen(other.text) + 1];
-        std::copy(other.text, other.text + strlen(other.text), text);
-    }
-    next = nullptr;
-}
-
 LinkedList::LinkedList() {
     head = nullptr;
     tail = nullptr;
@@ -33,4 +24,3 @@ LinkedList::~LinkedList() {
         current = next;
     }
 }
-

--- a/test/buffer_test.cpp
+++ b/test/buffer_test.cpp
@@ -5,9 +5,10 @@
 TEST(BufferTest, CutRemovesTextFromContent) {
     Buffer buffer;
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, world!");
-    buffer.cut(&content, &cmdLog,0, 0, 5);
+    Cursor c = Cursor();
+    Editor::newLine(&content, nullptr, "Hello, world!");
+    c.updateCursor(content.tail, content.length - 1, 0);
+    buffer.cut(nullptr, c, 5);
     EXPECT_STREQ(content.head->text, ", world!");
     EXPECT_STREQ(buffer.getClip(), "Hello");
 }
@@ -15,9 +16,10 @@ TEST(BufferTest, CutRemovesTextFromContent) {
 TEST(BufferTest, CopyDoesNotRemoveTextFromContent) {
     Buffer buffer;
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, world!");
-    buffer.copy(&content, 0, 0, 5);
+    Cursor c = Cursor();
+    Editor::newLine(&content, nullptr, "Hello, world!");
+    c.updateCursor(content.tail, content.length - 1, 0);
+    buffer.copy(c, 5);
     EXPECT_STREQ(content.head->text, "Hello, world!");
     EXPECT_STREQ(buffer.getClip(), "Hello");
 }
@@ -25,38 +27,44 @@ TEST(BufferTest, CopyDoesNotRemoveTextFromContent) {
 TEST(BufferTest, CopyLengthGreaterThanLineLength) {
     Buffer buffer;
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog,"Hello, world!");
-    buffer.copy(&content, 0, 0, 100);
+    Cursor c = Cursor();
+    Editor::newLine(&content, nullptr,"Hello, world!");
+    c.updateCursor(content.tail, content.length - 1, 0);
+    buffer.copy(c, 100);
     EXPECT_STREQ(buffer.getClip(), "Hello, world!");
 }
 
 TEST(BufferTest, CopyAfterCopy) {
     Buffer buffer;
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog,"Hello, world!");
-    buffer.copy(&content, 0, 0, 5);
+    Cursor c = Cursor();
+    Editor::newLine(&content, nullptr,"Hello, world!");
+    c.updateCursor(content.tail, content.length - 1, 0);
+    buffer.copy(c, 5);
     EXPECT_STREQ(buffer.getClip(), "Hello");
-    buffer.copy(&content, 0, 7, 5);
+    c.setCursor(&content, 0, 7);
+    buffer.copy(c, 5);
     EXPECT_STREQ(buffer.getClip(), "world");
 }
 
 TEST(BufferTest, PasteInsertsTextFromBufferToContent) {
     Buffer buffer;
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog,"Hello, world!");
-    buffer.copy(&content, 0, 0, 5);
-    buffer.paste(&content, &cmdLog, 0, 6);
+    Cursor c = Cursor();
+    Editor::newLine(&content, nullptr,"Hello, world!");
+    c.updateCursor(content.tail, content.length - 1, 0);
+    buffer.copy(c, 5);
+    c.setCursor(&content, 0, 6);
+    buffer.paste(nullptr, c);
     EXPECT_STREQ(content.head->text, "Hello,Hello world!");
 }
 
 TEST(BufferTest, PasteDoesNothingWhenBufferIsEmpty) {
     Buffer buffer;
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, world!");
-    buffer.paste(&content, &cmdLog, 0, 6);
+    Cursor c = Cursor();
+    Editor::newLine(&content, nullptr, "Hello, world!");
+    c.setCursor(&content, 0, 6);
+    buffer.paste(nullptr, c);
     EXPECT_STREQ(content.head->text, "Hello, world!");
 }

--- a/test/cursor_test.cpp
+++ b/test/cursor_test.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+#include "../include/cursor.h"
+#include "../include/editor.h"
+#include "../include/main_test.h"
+
+TEST(CursorTest, GetCursorLineReturnsCorrectLine) {
+    Line* line = new Line();
+    Cursor cursor = Cursor();
+    cursor.updateCursor(line, 0, 0);
+    EXPECT_EQ(cursor.getCursorLine(), line);
+}
+
+TEST(CursorTest, CursorMovesWithTheTail) {
+    LinkedList content;
+    CommandsLog cmdLog;
+    Cursor cursor = Cursor();
+    Editor::newLine(&content, &cmdLog, "test0");
+    cursor.updateCursor(content.tail, content.length - 1, 0);
+    EXPECT_EQ(cursor.getCursorLine(), content.tail);
+    Editor::newLine(&content, &cmdLog, "test1");
+    cursor.updateCursor(content.tail, content.length - 1, 0);
+    EXPECT_EQ(cursor.getCursorLine(), content.tail);
+}
+
+TEST(CursorTest, SetCursorUpdatesLineAndIndexes) {
+    LinkedList content;
+    CommandsLog cmdLog;
+    Cursor cursor = Cursor();
+    Editor::newLine(&content, &cmdLog, "test0");
+    Editor::newLine(&content, &cmdLog, "test1");
+    cursor.setCursor(&content, 1, 3);
+    EXPECT_EQ(cursor.getCursorLine(), content.head->next);
+    EXPECT_EQ(cursor.getCursorLineIndex(), 1);
+    EXPECT_EQ(cursor.getCursorCharIndex(), 3);
+}
+
+TEST(CursorTest, SetCursorDoesNotUpdateWhenLineIndexOutOfBounds) {
+    LinkedList content = LinkedList();
+    Cursor cursor = Cursor();
+    EXPECT_EQ(cursor.getCursorLine(), nullptr);
+    EXPECT_EQ(cursor.getCursorLineIndex(), 0);
+    EXPECT_EQ(cursor.getCursorCharIndex(), 0);
+    std::streambuf* cinbuf = redirectCin();
+    testing::internal::CaptureStderr();
+    cursor.setCursor(&content, 2, 0);
+    std::string output = testing::internal::GetCapturedStderr();
+    resetCin(cinbuf);
+    EXPECT_EQ(cursor.getCursorLine(), nullptr);
+    EXPECT_EQ(cursor.getCursorLineIndex(), 0);
+    EXPECT_EQ(cursor.getCursorCharIndex(), 0);
+    EXPECT_EQ(output, "Line index is out of bounds.");
+}
+
+TEST(CursorTest, SetCursorDoesNotUpdateWhenCharIndexOutOfBounds) {
+    LinkedList content = LinkedList();
+    CommandsLog cmdLog;
+    Cursor cursor = Cursor();
+    Editor::newLine(&content, &cmdLog, "test");
+    EXPECT_EQ(cursor.getCursorLine(), nullptr);
+    EXPECT_EQ(cursor.getCursorLineIndex(), 0);
+    EXPECT_EQ(cursor.getCursorCharIndex(), 0);
+    std::streambuf* cinbuf = redirectCin();
+    testing::internal::CaptureStderr();
+    cursor.setCursor(&content, 0, 5);
+    std::string output = testing::internal::GetCapturedStderr();
+    resetCin(cinbuf);
+    EXPECT_EQ(cursor.getCursorLine(), nullptr);
+    EXPECT_EQ(cursor.getCursorLineIndex(), 0);
+    EXPECT_EQ(cursor.getCursorCharIndex(), 0);
+    EXPECT_EQ(output, "Char index is out of bounds.");
+}

--- a/test/editor_test.cpp
+++ b/test/editor_test.cpp
@@ -4,25 +4,22 @@
 
 TEST(EditorTest, NewLineAddsLineToEmptyList) {
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
+    Editor::newLine(&content, nullptr, "Hello, World!");
     EXPECT_STREQ(content.head->text, "Hello, World!");
     EXPECT_EQ(content.length, 1);
 }
 
 TEST(EditorTest, NewLineAddsLineToNonEmptyList) {
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
-    Editor::newLine(&content, &cmdLog, "Hello, GitHub Copilot!");
+    Editor::newLine(&content, nullptr, "Hello, World!");
+    Editor::newLine(&content, nullptr, "Hello, GitHub Copilot!");
     EXPECT_STREQ(content.tail->text, "Hello, GitHub Copilot!");
     EXPECT_EQ(content.length, 2);
 }
 
 TEST(EditorTest, PrintTextOutputsCorrectly) {
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
+    Editor::newLine(&content, nullptr, "Hello, World!");
     testing::internal::CaptureStdout();
     Editor::printText(&content);
     std::string output = testing::internal::GetCapturedStdout();
@@ -31,24 +28,21 @@ TEST(EditorTest, PrintTextOutputsCorrectly) {
 
 TEST(EditorTest, AppendTextToEmptyList) {
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::appendText(&content, &cmdLog, "Hello, World!");
+    Editor::appendText(&content, nullptr, "Hello, World!");
     EXPECT_STREQ(content.head->text, "Hello, World!");
     EXPECT_EQ(content.length, 1);
 }
 
 TEST(EditorTest, AppendTextToNonEmptyList) {
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, ");
-    Editor::appendText(&content, &cmdLog, "World!");
+    Editor::newLine(&content, nullptr, "Hello, ");
+    Editor::appendText(&content, nullptr, "World!");
     EXPECT_STREQ(content.head->text, "Hello, World!");
 }
 
 TEST(EditorTest, SearchPatternNotFound) {
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
+    Editor::newLine(&content, nullptr, "Hello, World!");
     testing::internal::CaptureStdout();
     Editor::search(&content, "GitHub Copilot");
     std::string output = testing::internal::GetCapturedStdout();
@@ -57,8 +51,7 @@ TEST(EditorTest, SearchPatternNotFound) {
 
 TEST(EditorTest, SearchPatternFound) {
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, GitHub Copilot!");
+    Editor::newLine(&content, nullptr, "Hello, GitHub Copilot!");
     testing::internal::CaptureStdout();
     Editor::search(&content, "GitHub Copilot");
     std::string output = testing::internal::GetCapturedStdout();
@@ -67,92 +60,37 @@ TEST(EditorTest, SearchPatternFound) {
 
 TEST(EditorTest, InsertByInBounds) {
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
-    Editor::insertBy(&content, &cmdLog, 0, 7, "GitHub Copilot, ");
+    Cursor c = Cursor();
+    Editor::newLine(&content, nullptr, "Hello, World!");
+    c.setCursor(&content, 0, 7);
+    Editor::insertText(nullptr, c, "GitHub Copilot, ");
     EXPECT_STREQ(content.head->text, "Hello, GitHub Copilot, World!");
-}
-
-TEST(EditorTest, InsertByOutOfBounds) {
-    LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
-    std::streambuf* cinbuf = redirectCin();  // Redirect std::cin and save the old buffer
-    testing::internal::CaptureStderr();
-    Editor::insertBy(&content, &cmdLog, 2, 0, "GitHub Copilot, ");
-    std::string output = testing::internal::GetCapturedStderr();
-    resetCin(cinbuf);  // Restore the original buffer
-    EXPECT_EQ(output, "Line index is out of bounds.");
 }
 
 TEST(EditorTest, ReplaceByValidIndex) {
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
-    Editor::replaceBy(&content, &cmdLog, 0, 7, "GitHub Copilot");
+    Cursor c = Cursor();
+    Editor::newLine(&content, nullptr, "Hello, World!");
+    c.setCursor(&content, 0, 7);
+    Editor::replaceText(nullptr, c, "GitHub Copilot");
     EXPECT_STREQ(content.head->text, "Hello, GitHub Copilot");
-}
-
-TEST(EditorTest, ReplaceByInvalidLineIndex) {
-    LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
-    std::streambuf* cinbuf = redirectCin();
-    testing::internal::CaptureStderr();
-    Editor::replaceBy(&content, &cmdLog, 2, 7, "GitHub Copilot");
-    std::string output = testing::internal::GetCapturedStderr();
-    resetCin(cinbuf);
-    EXPECT_EQ(output, "Line index is out of bounds.");
-}
-
-TEST(EditorTest, ReplaceByInvalidCharIndex) {
-    LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
-    std::streambuf* cinbuf = redirectCin();
-    testing::internal::CaptureStderr();
-    Editor::replaceBy(&content, &cmdLog, 0, 20, "GitHub Copilot");
-    std::string output = testing::internal::GetCapturedStderr();
-    resetCin(cinbuf);
-    EXPECT_EQ(output, "Char index is out of bounds.");
 }
 
 TEST(EditorTest, DeleteByValidIndexAndLength) {
     LinkedList content;
     CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
-    Editor::deleteBy(&content, &cmdLog, 0, 7, 5);
+    Cursor c = Cursor();
+    Editor::newLine(&content, nullptr, "Hello, World!");
+    c.setCursor(&content, 0, 7);
+    Editor::deleteText(nullptr, c, 5);
     EXPECT_STREQ(content.head->text, "Hello, !");
-}
-
-TEST(EditorTest, DeleteByInvalidLineIndex) {
-    LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
-    std::streambuf* cinbuf = redirectCin();
-    testing::internal::CaptureStderr();
-    Editor::deleteBy(&content, &cmdLog, 2, 7, 5);
-    std::string output = testing::internal::GetCapturedStderr();
-    resetCin(cinbuf);
-    EXPECT_EQ(output, "Line index is out of bounds.");
-}
-
-TEST(EditorTest, DeleteByInvalidCharIndex) {
-    LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
-    std::streambuf* cinbuf = redirectCin();
-    testing::internal::CaptureStderr();
-    Editor::deleteBy(&content, &cmdLog, 0, 20, 5);
-    std::string output = testing::internal::GetCapturedStderr();
-    resetCin(cinbuf);
-    EXPECT_EQ(output, "Char index is out of bounds.");
 }
 
 TEST(EditorTest, DeleteByLengthExceedsRemainingCharacters) {
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
-    Editor::deleteBy(&content, &cmdLog, 0, 7, 20);
+    Cursor c = Cursor();
+    Editor::newLine(&content, nullptr, "Hello, World!");
+    c.setCursor(&content, 0, 7);
+    Editor::deleteText(nullptr, c, 20);
     EXPECT_STREQ(content.head->text, "Hello, ");
 }

--- a/test/file_handler_test.cpp
+++ b/test/file_handler_test.cpp
@@ -5,11 +5,10 @@
 
 TEST(FileHandlerTest, SaveAndLoadEmptyFile) {
     LinkedList content;
-    CommandsLog cmdLog;
     std::streambuf* coutbuf = redirectCout();
     FileHandler::saveToFile(&content, "empty.txt");
     LinkedList loadedContent;
-    FileHandler::loadFromFile(&loadedContent, &cmdLog, "empty.txt");
+    FileHandler::loadFromFile(&loadedContent, nullptr, "empty.txt");
     resetCout(coutbuf);
     EXPECT_EQ(loadedContent.length, 0);
     EXPECT_EQ(loadedContent.head, nullptr);
@@ -17,12 +16,11 @@ TEST(FileHandlerTest, SaveAndLoadEmptyFile) {
 
 TEST(FileHandlerTest, SaveAndLoadFile) {
     LinkedList content;
-    CommandsLog cmdLog;
-    Editor::newLine(&content, &cmdLog, "Hello, World!");
+    Editor::newLine(&content, nullptr, "Hello, World!");
     std::streambuf* coutbuf = redirectCout();
     FileHandler::saveToFile(&content, "hello.txt");
     LinkedList loadedContent;
-    FileHandler::loadFromFile(&loadedContent, &cmdLog, "hello.txt");
+    FileHandler::loadFromFile(&loadedContent, nullptr, "hello.txt");
     resetCout(coutbuf);
     EXPECT_STREQ(loadedContent.head->text, content.head->text);
 }


### PR DESCRIPTION
## Description
This PR introduces cursor-based logic to the application, specifically affecting `insert`, `replace`, `delete`, `cut`, `copy`, and `paste` commands to utilize the new cursor functionality.

## Changes
- `cursor.h`, `cursor.cpp`:
    - Defined the `Cursor` class with methods to get and set the cursor position.
- Application Integration:
    - Revised `insert`, `replace`, `delete by`, `cut`, `copy`, and `paste` commands to use the cursor.

## Test cases
1. **GetCursorLineReturnsCorrectLine**:
    - **Input**: `Line* line = new Line(); Cursor cursor = Cursor(); cursor.updateCursor(line, 0, 0);`
    - **Result**: Cursor's line should be the same as the provided line.
2. **CursorMovesWithTheTail**:
    - **Input**: `LinkedList content; CommandsLog cmdLog; Cursor cursor = Cursor(); Editor::newLine(&content, &cmdLog, "test0"); cursor.updateCursor(content.tail, content.length - 1, 0);`
    - **Result**: Cursor should move with the tail of the content.
3. **SetCursorUpdatesLineAndIndexes**:
    - **Input**: `LinkedList content; CommandsLog cmdLog; Cursor cursor = Cursor(); Editor::newLine(&content, &cmdLog, "test0"); Editor::newLine(&content, &cmdLog, "test1"); cursor.setCursor(&content, 1, 3);`
    - **Result**: Cursor's line and indexes should be updated correctly.
4. **SetCursorDoesNotUpdateWhenLineIndexOutOfBounds**:
    - **Input**: `LinkedList content = LinkedList(); Cursor cursor = Cursor(); cursor.setCursor(&content, 2, 0);`
    - **Result**: Cursor should not update and should produce an "out of bounds" error.
5. **SetCursorDoesNotUpdateWhenCharIndexOutOfBounds**:
    - **Input**: `LinkedList content = LinkedList(); CommandsLog cmdLog; Cursor cursor = Cursor(); Editor::newLine(&content, &cmdLog, "test"); cursor.setCursor(&content, 0, 5);`
    - **Result**: Cursor should not update and should produce an "out of bounds" error.

## Screenshots
<img width="617" alt="image" src="https://github.com/kzholtikova/simple-text-editor/assets/145042018/4376f6f4-c105-4466-92f0-2cc2a73f9013">